### PR TITLE
Add events and RSVPs for groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 1.2"
 gem "devise"
+gem "redcarpet"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,6 +280,7 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
+    redcarpet (3.6.1)
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -413,6 +414,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.1.2)
+  redcarpet
   rspec-rails
   rubocop-rails-omakase
   solid_cable
@@ -527,6 +529,7 @@ CHECKSUMS
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
+  redcarpet (3.6.1) sha256=d444910e6aa55480c6bcdc0cdb057626e8a32c054c29e793fa642ba2f155f445
   regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   responders (3.2.0) sha256=89c2d6ac0ae16f6458a11524cae4a8efdceba1a3baea164d28ee9046bd3df55a

--- a/app/controllers/concerns/event_authorization.rb
+++ b/app/controllers/concerns/event_authorization.rb
@@ -1,0 +1,26 @@
+module EventAuthorization
+  extend ActiveSupport::Concern
+
+  private
+
+  def require_event_organizer!
+    return if @event.group.organizer?(current_user)
+    redirect_to @event, alert: "Only organizers can do that."
+  end
+
+  def require_event_visible!
+    event = @event
+    case event.status
+    when "published"
+      if event.visibility == "private"
+        unless user_signed_in? && event.group.member?(current_user)
+          redirect_to root_path, alert: "You must be a group member to view this event."
+        end
+      end
+    when "draft", "canceled"
+      unless user_signed_in? && event.group.organizer?(current_user)
+        redirect_to root_path, alert: "You are not authorized to view this event."
+      end
+    end
+  end
+end

--- a/app/controllers/event_rsvps_controller.rb
+++ b/app/controllers/event_rsvps_controller.rb
@@ -1,0 +1,32 @@
+class EventRsvpsController < ApplicationController
+  before_action :set_event, only: [ :create ]
+  before_action :set_rsvp, only: [ :destroy ]
+
+  def create
+    @rsvp = @event.event_rsvps.build(user: current_user)
+    if @rsvp.save
+      redirect_to @event, notice: "You're going!"
+    else
+      redirect_to @event, alert: @rsvp.errors.full_messages.to_sentence
+    end
+  end
+
+  def destroy
+    unless @rsvp.user == current_user
+      redirect_to @rsvp.event, alert: "You can only cancel your own RSVP."
+      return
+    end
+    @rsvp.destroy
+    redirect_to @rsvp.event, notice: "Your RSVP has been canceled."
+  end
+
+  private
+
+  def set_event
+    @event = Event.find(params[:event_id])
+  end
+
+  def set_rsvp
+    @rsvp = EventRsvp.find(params[:id])
+  end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,81 @@
+class EventsController < ApplicationController
+  include EventAuthorization
+
+  skip_before_action :authenticate_user!, only: [ :show ]
+  before_action :set_group, only: [ :index, :new, :create ]
+  before_action :set_event, only: [ :show, :edit, :update, :destroy ]
+  before_action :require_event_visible!, only: [ :show ]
+  before_action :require_group_member_or_organizer!, only: [ :index ]
+  before_action :require_group_organizer!, only: [ :new, :create ]
+  before_action :require_event_organizer!, only: [ :edit, :update, :destroy ]
+
+  def index
+    @events = if @group.organizer?(current_user)
+      @group.events.order(starts_at: :asc)
+    else
+      @group.events.published.order(starts_at: :asc)
+    end
+  end
+
+  def show
+    @rsvp_count = @event.event_rsvps.count
+    @user_rsvp = current_user ? @event.event_rsvps.find_by(user: current_user) : nil
+  end
+
+  def new
+    @event = @group.events.build
+  end
+
+  def create
+    @event = @group.events.build(event_params)
+    if @event.save
+      redirect_to @event, notice: "Event was created successfully."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @event.update(event_params)
+      redirect_to @event, notice: "Event was updated successfully."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    group = @event.group
+    @event.destroy
+    redirect_to group_events_path(group), notice: "Event was deleted."
+  end
+
+  private
+
+  def set_group
+    @group = Group.find(params[:group_id])
+  end
+
+  def set_event
+    @event = Event.find(params[:id])
+  end
+
+  def require_group_member_or_organizer!
+    unless @group.member?(current_user)
+      redirect_to @group, alert: "You must be a member to view this group's events."
+    end
+  end
+
+  def require_group_organizer!
+    unless @group.organizer?(current_user)
+      redirect_to @group, alert: "Only organizers can do that."
+    end
+  end
+
+  def event_params
+    params.expect(event: [ :title, :description, :starts_at, :ends_at, :location,
+                            :status, :visibility, :rsvp_limit, :rsvp_opens_at, :rsvp_closes_at ])
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,16 @@
 class PagesController < ApplicationController
   def home
+    group_ids = current_user.group_memberships.pluck(:group_id)
+    @upcoming_events = Event.published
+                            .where(group_id: group_ids)
+                            .upcoming
+                            .order(:starts_at)
+                            .limit(6)
+    @discover_events = Event.published
+                            .public_visibility
+                            .where.not(group_id: group_ids)
+                            .upcoming
+                            .order(:starts_at)
+                            .limit(6)
   end
 end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -2,5 +2,6 @@ class StaticController < ApplicationController
   skip_before_action :authenticate_user!
 
   def index
+    @upcoming_events = Event.published.public_visibility.upcoming.order(:starts_at).limit(6)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,8 @@
 module ApplicationHelper
+  def render_markdown(text)
+    return "" if text.blank?
+    renderer = Redcarpet::Render::HTML.new(safe_links_only: true, no_styles: true)
+    markdown = Redcarpet::Markdown.new(renderer, autolink: true, tables: true, fenced_code_blocks: true, no_intra_emphasis: true)
+    sanitize(markdown.render(text))
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,44 @@
+class Event < ApplicationRecord
+  belongs_to :group
+  has_many :event_rsvps, dependent: :destroy
+  has_many :rsvpers, through: :event_rsvps, source: :user
+
+  STATUSES = %w[draft published canceled].freeze
+  VISIBILITIES = %w[public private].freeze
+
+  validates :title, presence: true
+  validates :starts_at, presence: true
+  validates :ends_at, presence: true
+  validates :status, inclusion: { in: STATUSES }
+  validates :visibility, inclusion: { in: VISIBILITIES }
+  validate :ends_at_after_starts_at
+
+  scope :published,         -> { where(status: "published") }
+  scope :draft,             -> { where(status: "draft") }
+  scope :canceled,          -> { where(status: "canceled") }
+  scope :public_visibility, -> { where(visibility: "public") }
+  scope :upcoming,          -> { where("starts_at >= ?", Time.current) }
+
+  def rsvp_open?
+    return false unless status == "published"
+    return false if rsvp_opens_at.present? && rsvp_opens_at > Time.current
+    return false if rsvp_closes_at.present? && rsvp_closes_at <= Time.current
+    true
+  end
+
+  def rsvp_full?
+    rsvp_limit.present? && event_rsvps.count >= rsvp_limit
+  end
+
+  def rsvped_by?(user)
+    return false if user.nil?
+    event_rsvps.exists?(user: user)
+  end
+
+  private
+
+  def ends_at_after_starts_at
+    return unless starts_at.present? && ends_at.present?
+    errors.add(:ends_at, "must be after start time") if ends_at <= starts_at
+  end
+end

--- a/app/models/event_rsvp.rb
+++ b/app/models/event_rsvp.rb
@@ -1,0 +1,19 @@
+class EventRsvp < ApplicationRecord
+  belongs_to :event
+  belongs_to :user
+
+  validates :user_id, uniqueness: { scope: :event_id, message: "has already RSVPed to this event" }
+  validate :event_must_accept_rsvps, on: :create
+
+  private
+
+  def event_must_accept_rsvps
+    return unless event.present?
+    unless event.rsvp_open?
+      errors.add(:base, "RSVPs are not currently open for this event")
+    end
+    if event.rsvp_full?
+      errors.add(:base, "This event has reached its RSVP limit")
+    end
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,6 @@
 class Group < ApplicationRecord
   has_many :group_memberships, dependent: :destroy
+  has_many :events, dependent: :destroy
   has_many :users, through: :group_memberships
 
   has_many :organizer_memberships,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   has_many :group_memberships, dependent: :destroy
   has_many :groups, through: :group_memberships
+  has_many :event_rsvps, dependent: :destroy
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,0 +1,68 @@
+<%= form_with(model: event.persisted? ? event : [@group || event.group, event], class: "space-y-4") do |f| %>
+  <%= render "devise/shared/error_messages", resource: event %>
+
+  <div class="form-control">
+    <%= f.label :title, class: "label" %>
+    <%= f.text_field :title, class: "input input-bordered w-full", required: true %>
+  </div>
+
+  <div class="form-control">
+    <%= f.label :description, class: "label" %>
+    <span class="label-text-alt text-base-content/50">Supports Markdown</span>
+    <%= f.text_area :description, class: "textarea textarea-bordered w-full", rows: 6 %>
+  </div>
+
+  <div class="grid gap-4 sm:grid-cols-2">
+    <div class="form-control">
+      <%= f.label :starts_at, "Start time", class: "label" %>
+      <%= f.datetime_local_field :starts_at, class: "input input-bordered w-full", required: true %>
+    </div>
+
+    <div class="form-control">
+      <%= f.label :ends_at, "End time", class: "label" %>
+      <%= f.datetime_local_field :ends_at, class: "input input-bordered w-full", required: true %>
+    </div>
+  </div>
+
+  <div class="form-control">
+    <%= f.label :location, class: "label" %>
+    <%= f.text_field :location, class: "input input-bordered w-full", placeholder: "e.g. 123 Main St or Zoom link" %>
+  </div>
+
+  <div class="grid gap-4 sm:grid-cols-2">
+    <div class="form-control">
+      <%= f.label :visibility, class: "label" %>
+      <%= f.select :visibility, Event::VISIBILITIES.map { |v| [v.capitalize, v] },
+          {}, class: "select select-bordered w-full" %>
+    </div>
+
+    <div class="form-control">
+      <%= f.label :status, class: "label" %>
+      <%= f.select :status, Event::STATUSES.map { |s| [s.capitalize, s] },
+          {}, class: "select select-bordered w-full" %>
+    </div>
+  </div>
+
+  <div class="divider">RSVP Settings <span class="text-base-content/50 font-normal text-sm">(optional)</span></div>
+
+  <div class="form-control">
+    <%= f.label :rsvp_limit, "Max attendees", class: "label" %>
+    <%= f.number_field :rsvp_limit, class: "input input-bordered w-full", min: 1, placeholder: "Unlimited" %>
+  </div>
+
+  <div class="grid gap-4 sm:grid-cols-2">
+    <div class="form-control">
+      <%= f.label :rsvp_opens_at, "RSVPs open at", class: "label" %>
+      <%= f.datetime_local_field :rsvp_opens_at, class: "input input-bordered w-full" %>
+    </div>
+
+    <div class="form-control">
+      <%= f.label :rsvp_closes_at, "RSVPs close at", class: "label" %>
+      <%= f.datetime_local_field :rsvp_closes_at, class: "input input-bordered w-full" %>
+    </div>
+  </div>
+
+  <div class="form-control mt-6">
+    <%= f.submit class: "btn btn-primary w-full" %>
+  </div>
+<% end %>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, "Edit Event — #{@event.title}" %>
+
+<div class="container mx-auto p-6 max-w-2xl">
+  <div class="mb-6">
+    <h1 class="text-3xl font-bold">Edit Event</h1>
+    <p class="text-base-content/70 mt-1">for <%= link_to @event.group.name, @event.group, class: "link link-hover" %></p>
+  </div>
+
+  <%= render "form", event: @event, group: @event.group %>
+
+  <%= link_to "← Back to event", @event, class: "link link-hover text-sm mt-4 inline-block" %>
+</div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,0 +1,51 @@
+<% content_for :title, "Events — #{@group.name}" %>
+
+<div class="container mx-auto p-6 max-w-4xl">
+  <div class="flex items-center justify-between mb-6">
+    <div>
+      <h1 class="text-3xl font-bold">Events</h1>
+      <p class="text-base-content/70 mt-1"><%= link_to @group.name, @group, class: "link link-hover" %></p>
+    </div>
+    <% if @group.organizer?(current_user) %>
+      <%= link_to "New Event", new_group_event_path(@group), class: "btn btn-primary" %>
+    <% end %>
+  </div>
+
+  <% if @events.empty? %>
+    <div class="text-center py-16 text-base-content/50">
+      <p class="text-lg">No events yet.</p>
+      <% if @group.organizer?(current_user) %>
+        <p class="mt-2"><%= link_to "Create the first one", new_group_event_path(@group), class: "link" %></p>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="grid gap-4 sm:grid-cols-2">
+      <% @events.each do |event| %>
+        <div class="card bg-base-100 shadow">
+          <div class="card-body">
+            <div class="flex flex-wrap gap-1 mb-1">
+              <span class="badge badge-sm <%= event.status == 'published' ? 'badge-success' : event.status == 'canceled' ? 'badge-error' : 'badge-ghost' %>">
+                <%= event.status %>
+              </span>
+              <% if event.visibility == "private" %>
+                <span class="badge badge-sm badge-outline">private</span>
+              <% end %>
+            </div>
+            <h2 class="card-title text-base"><%= event.title %></h2>
+            <p class="text-base-content/70 text-sm">
+              <%= event.starts_at.strftime("%b %-d, %Y · %-I:%M %p") %>
+            </p>
+            <% if event.location.present? %>
+              <p class="text-base-content/50 text-sm line-clamp-1"><%= event.location %></p>
+            <% end %>
+            <div class="card-actions justify-end mt-2">
+              <%= link_to "View", event, class: "btn btn-sm btn-primary" %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
+  <%= link_to "← Back to group", @group, class: "link link-hover text-sm mt-6 inline-block" %>
+</div>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, "New Event — #{@group.name}" %>
+
+<div class="container mx-auto p-6 max-w-2xl">
+  <div class="mb-6">
+    <h1 class="text-3xl font-bold">New Event</h1>
+    <p class="text-base-content/70 mt-1">for <%= link_to @group.name, @group, class: "link link-hover" %></p>
+  </div>
+
+  <%= render "form", event: @event, group: @group %>
+
+  <%= link_to "← Back to events", group_events_path(@group), class: "link link-hover text-sm mt-4 inline-block" %>
+</div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,0 +1,95 @@
+<% content_for :title, @event.title %>
+
+<div class="container mx-auto p-6 max-w-2xl">
+  <%# Header %>
+  <div class="flex items-start justify-between mb-4">
+    <div class="flex-1">
+      <div class="flex flex-wrap items-center gap-2 mb-2">
+        <span class="badge <%= @event.status == 'published' ? 'badge-success' : @event.status == 'canceled' ? 'badge-error' : 'badge-ghost' %>">
+          <%= @event.status %>
+        </span>
+        <span class="badge badge-outline">
+          <%= @event.visibility %>
+        </span>
+      </div>
+      <h1 class="text-3xl font-bold"><%= @event.title %></h1>
+      <p class="text-base-content/70 mt-1">
+        <%= link_to @event.group.name, @event.group, class: "link link-hover" %>
+      </p>
+    </div>
+    <% if user_signed_in? && @event.group.organizer?(current_user) %>
+      <div class="flex gap-2 ml-4">
+        <%= link_to "Edit", edit_event_path(@event), class: "btn btn-sm btn-ghost" %>
+        <%= button_to "Delete", @event, method: :delete, class: "btn btn-sm btn-error btn-outline",
+            data: { turbo_confirm: "Delete this event?" } %>
+      </div>
+    <% end %>
+  </div>
+
+  <%# Time and location %>
+  <div class="card bg-base-100 shadow mb-4">
+    <div class="card-body py-4">
+      <div class="flex flex-col gap-1 text-sm">
+        <div class="flex items-center gap-2">
+          <span class="font-semibold">Starts:</span>
+          <span><%= @event.starts_at.strftime("%A, %B %-d, %Y at %-I:%M %p") %></span>
+        </div>
+        <div class="flex items-center gap-2">
+          <span class="font-semibold">Ends:</span>
+          <span><%= @event.ends_at.strftime("%A, %B %-d, %Y at %-I:%M %p") %></span>
+        </div>
+        <% if @event.location.present? %>
+          <div class="flex items-center gap-2">
+            <span class="font-semibold">Location:</span>
+            <span><%= @event.location %></span>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <%# Description %>
+  <% if @event.description.present? %>
+    <div class="card bg-base-100 shadow mb-4">
+      <div class="card-body prose max-w-none">
+        <%= render_markdown(@event.description) %>
+      </div>
+    </div>
+  <% end %>
+
+  <%# RSVP section %>
+  <% if @event.status == "published" %>
+    <div class="card bg-base-100 shadow mb-4">
+      <div class="card-body">
+        <h2 class="card-title text-lg">RSVPs</h2>
+
+        <div class="text-sm text-base-content/70 mb-3">
+          <%= @rsvp_count %> <%= "person".pluralize(@rsvp_count) %> going
+          <% if @event.rsvp_limit.present? %>
+            &middot; <%= @event.rsvp_limit - @rsvp_count %> spots remaining
+          <% end %>
+        </div>
+
+        <% if @event.rsvp_opens_at.present? && @event.rsvp_opens_at > Time.current %>
+          <p class="text-sm text-base-content/50">RSVPs open <%= @event.rsvp_opens_at.strftime("%B %-d at %-I:%M %p") %></p>
+        <% elsif @event.rsvp_closes_at.present? && @event.rsvp_closes_at <= Time.current %>
+          <p class="text-sm text-base-content/50">RSVPs are closed.</p>
+        <% elsif user_signed_in? %>
+          <% if @user_rsvp %>
+            <%= button_to "Cancel RSVP", event_rsvp_path(@user_rsvp), method: :delete,
+                class: "btn btn-sm btn-ghost",
+                data: { turbo_confirm: "Cancel your RSVP?" } %>
+          <% elsif @event.rsvp_full? %>
+            <button class="btn btn-sm btn-disabled" disabled>Event is full</button>
+          <% else %>
+            <%= button_to "RSVP", event_event_rsvps_path(@event), method: :post, class: "btn btn-sm btn-primary" %>
+          <% end %>
+        <% else %>
+          <%= link_to "Sign in to RSVP", new_user_session_path, class: "btn btn-sm btn-primary" %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
+  <%= link_to "← Back to events", group_events_path(@event.group), class: "link link-hover text-sm mt-4 inline-block" %>
+</div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -53,6 +53,35 @@
     </div>
   </div>
 
+  <%# Upcoming events %>
+  <% upcoming_events = @group.organizer?(current_user) ?
+      @group.events.published.upcoming.order(:starts_at).limit(3) :
+      @group.events.published.upcoming.order(:starts_at).limit(3) %>
+  <div class="card bg-base-100 shadow mb-4">
+    <div class="card-body">
+      <div class="flex items-center justify-between">
+        <h2 class="card-title text-lg">Upcoming Events</h2>
+        <%= link_to "View all", group_events_path(@group), class: "link link-hover text-sm" %>
+      </div>
+
+      <% if upcoming_events.empty? %>
+        <p class="text-base-content/50 text-sm">No upcoming events.</p>
+        <% if @group.organizer?(current_user) %>
+          <%= link_to "Create an event", new_group_event_path(@group), class: "btn btn-sm btn-primary mt-2 self-start" %>
+        <% end %>
+      <% else %>
+        <ul class="divide-y divide-base-200">
+          <% upcoming_events.each do |event| %>
+            <li class="py-2">
+              <%= link_to event.title, event, class: "font-medium hover:underline" %>
+              <p class="text-base-content/60 text-xs mt-0.5"><%= event.starts_at.strftime("%b %-d, %Y · %-I:%M %p") %></p>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+    </div>
+  </div>
+
   <% unless @group.member?(current_user) %>
     <div class="text-center">
       <%= button_to "Join Group", group_group_memberships_path(@group), method: :post, class: "btn btn-primary" %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,4 +1,53 @@
 <div class="container mx-auto p-6 max-w-4xl">
+  <% if @upcoming_events.any? %>
+    <div class="mb-8">
+      <h2 class="text-xl font-semibold mb-4">Upcoming Events</h2>
+      <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <% @upcoming_events.each do |event| %>
+          <div class="card bg-base-100 shadow">
+            <div class="card-body">
+              <% if event.visibility == "private" %>
+                <span class="badge badge-sm badge-outline self-start">private</span>
+              <% end %>
+              <h3 class="card-title text-base"><%= event.title %></h3>
+              <p class="text-base-content/70 text-sm"><%= event.starts_at.strftime("%b %-d, %Y · %-I:%M %p") %></p>
+              <% if event.location.present? %>
+                <p class="text-base-content/50 text-sm line-clamp-1"><%= event.location %></p>
+              <% end %>
+              <p class="text-base-content/50 text-xs"><%= event.group.name %></p>
+              <div class="card-actions justify-end mt-1">
+                <%= link_to "View", event, class: "btn btn-sm btn-primary" %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
+  <% if @discover_events.any? %>
+    <div class="mb-8">
+      <h2 class="text-xl font-semibold mb-4">Discover Events</h2>
+      <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <% @discover_events.each do |event| %>
+          <div class="card bg-base-100 shadow">
+            <div class="card-body">
+              <h3 class="card-title text-base"><%= event.title %></h3>
+              <p class="text-base-content/70 text-sm"><%= event.starts_at.strftime("%b %-d, %Y · %-I:%M %p") %></p>
+              <% if event.location.present? %>
+                <p class="text-base-content/50 text-sm line-clamp-1"><%= event.location %></p>
+              <% end %>
+              <p class="text-base-content/50 text-xs"><%= event.group.name %></p>
+              <div class="card-actions justify-end mt-1">
+                <%= link_to "View", event, class: "btn btn-sm btn-ghost" %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
   <div class="mb-4 flex items-center justify-between">
     <h2 class="text-xl font-semibold">My Groups</h2>
     <%= link_to "Browse all groups", groups_path, class: "link link-hover text-sm" %>

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -19,3 +19,26 @@
     </div>
   </div>
 </div>
+
+<% if @upcoming_events.any? %>
+  <div class="container mx-auto px-6 pb-12 max-w-4xl">
+    <h2 class="text-2xl font-bold mb-4">Upcoming Events</h2>
+    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <% @upcoming_events.each do |event| %>
+        <div class="card bg-base-100 shadow">
+          <div class="card-body">
+            <h3 class="card-title text-base"><%= event.title %></h3>
+            <p class="text-base-content/70 text-sm"><%= event.starts_at.strftime("%b %-d, %Y · %-I:%M %p") %></p>
+            <% if event.location.present? %>
+              <p class="text-base-content/50 text-sm line-clamp-1"><%= event.location %></p>
+            <% end %>
+            <p class="text-base-content/50 text-xs"><%= event.group.name %></p>
+            <div class="card-actions justify-end mt-1">
+              <%= link_to "View", event, class: "btn btn-sm btn-primary" %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,9 @@
     "": {
       "name": "calmendar",
       "dependencies": {
-        "@tailwindcss/cli": "latest",
-        "daisyui": "latest",
-        "tailwindcss": "latest",
+        "@tailwindcss/cli": "^4.2.2",
+        "daisyui": "^5.5.19",
+        "tailwindcss": "^4.2.2",
       },
     },
   },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
 
   resources :groups do
     resources :group_memberships, only: [ :create, :update, :destroy ], shallow: true
+    resources :events, shallow: true do
+      resources :event_rsvps, only: [ :create, :destroy ], shallow: true
+    end
   end
 
   root "static#index"

--- a/db/migrate/20260404133049_create_events.rb
+++ b/db/migrate/20260404133049_create_events.rb
@@ -1,0 +1,22 @@
+class CreateEvents < ActiveRecord::Migration[8.1]
+  def change
+    create_table :events do |t|
+      t.references :group, null: false, foreign_key: true
+      t.string     :title,          null: false
+      t.text       :description
+      t.datetime   :starts_at,      null: false
+      t.datetime   :ends_at,        null: false
+      t.string     :location
+      t.string     :status,         null: false, default: "draft"
+      t.string     :visibility,     null: false, default: "public"
+      t.integer    :rsvp_limit
+      t.datetime   :rsvp_opens_at
+      t.datetime   :rsvp_closes_at
+
+      t.timestamps
+    end
+
+    add_index :events, [ :group_id, :status ]
+    add_index :events, :starts_at
+  end
+end

--- a/db/migrate/20260404133050_create_event_rsvps.rb
+++ b/db/migrate/20260404133050_create_event_rsvps.rb
@@ -1,0 +1,12 @@
+class CreateEventRsvps < ActiveRecord::Migration[8.1]
+  def change
+    create_table :event_rsvps do |t|
+      t.references :event, null: false, foreign_key: true
+      t.references :user,  null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :event_rsvps, [ :event_id, :user_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,38 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_29_113924) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_04_133050) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "event_rsvps", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "event_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["event_id", "user_id"], name: "index_event_rsvps_on_event_id_and_user_id", unique: true
+    t.index ["event_id"], name: "index_event_rsvps_on_event_id"
+    t.index ["user_id"], name: "index_event_rsvps_on_user_id"
+  end
+
+  create_table "events", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.datetime "ends_at", null: false
+    t.bigint "group_id", null: false
+    t.string "location"
+    t.datetime "rsvp_closes_at"
+    t.integer "rsvp_limit"
+    t.datetime "rsvp_opens_at"
+    t.datetime "starts_at", null: false
+    t.string "status", default: "draft", null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.string "visibility", default: "public", null: false
+    t.index ["group_id", "status"], name: "index_events_on_group_id_and_status"
+    t.index ["group_id"], name: "index_events_on_group_id"
+    t.index ["starts_at"], name: "index_events_on_starts_at"
+  end
 
   create_table "group_memberships", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -46,6 +75,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_29_113924) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "event_rsvps", "events"
+  add_foreign_key "event_rsvps", "users"
+  add_foreign_key "events", "groups"
   add_foreign_key "group_memberships", "groups"
   add_foreign_key "group_memberships", "users"
 end

--- a/spec/models/event_rsvp_spec.rb
+++ b/spec/models/event_rsvp_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+
+RSpec.describe EventRsvp, type: :model do
+  let(:group) { Group.create!(name: "Test Group") }
+  let(:user)  { User.create!(email: "user@example.com", password: "password") }
+  let(:other_user) { User.create!(email: "other@example.com", password: "password") }
+  let(:base_time) { Time.current.change(sec: 0) }
+
+  def published_event(overrides = {})
+    Event.create!({
+      group: group,
+      title: "Open Event",
+      starts_at: base_time + 1.day,
+      ends_at: base_time + 1.day + 2.hours,
+      status: "published",
+      visibility: "public"
+    }.merge(overrides))
+  end
+
+  describe "associations" do
+    it "belongs to event" do
+      expect(described_class.reflect_on_association(:event).macro).to eq(:belongs_to)
+    end
+
+    it "belongs to user" do
+      expect(described_class.reflect_on_association(:user).macro).to eq(:belongs_to)
+    end
+  end
+
+  describe "uniqueness validation" do
+    it "prevents the same user from RSVPing twice to the same event" do
+      event = published_event
+      EventRsvp.create!(event: event, user: user)
+      duplicate = EventRsvp.new(event: event, user: user)
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:user_id]).to be_present
+    end
+
+    it "allows the same user to RSVP to different events" do
+      event1 = published_event(title: "Event 1")
+      event2 = published_event(title: "Event 2")
+      EventRsvp.create!(event: event1, user: user)
+      expect(EventRsvp.new(event: event2, user: user)).to be_valid
+    end
+
+    it "allows different users to RSVP to the same event" do
+      event = published_event
+      EventRsvp.create!(event: event, user: user)
+      expect(EventRsvp.new(event: event, user: other_user)).to be_valid
+    end
+  end
+
+  describe "#event_must_accept_rsvps" do
+    it "blocks RSVP when event is a draft" do
+      event = Event.create!(group: group, title: "Draft", starts_at: base_time + 1.day,
+                            ends_at: base_time + 1.day + 1.hour, status: "draft")
+      rsvp = EventRsvp.new(event: event, user: user)
+      expect(rsvp).not_to be_valid
+      expect(rsvp.errors[:base]).to be_present
+    end
+
+    it "blocks RSVP when event is canceled" do
+      event = Event.create!(group: group, title: "Canceled", starts_at: base_time + 1.day,
+                            ends_at: base_time + 1.day + 1.hour, status: "canceled")
+      rsvp = EventRsvp.new(event: event, user: user)
+      expect(rsvp).not_to be_valid
+    end
+
+    it "blocks RSVP when rsvp_opens_at is in the future" do
+      event = published_event(rsvp_opens_at: 1.hour.from_now)
+      rsvp = EventRsvp.new(event: event, user: user)
+      expect(rsvp).not_to be_valid
+    end
+
+    it "blocks RSVP when rsvp_closes_at is in the past" do
+      event = published_event(rsvp_closes_at: 1.hour.ago)
+      rsvp = EventRsvp.new(event: event, user: user)
+      expect(rsvp).not_to be_valid
+    end
+
+    it "blocks RSVP when event is full" do
+      event = published_event(rsvp_limit: 1)
+      EventRsvp.create!(event: event, user: other_user)
+      rsvp = EventRsvp.new(event: event, user: user)
+      expect(rsvp).not_to be_valid
+      expect(rsvp.errors[:base].join).to include("limit")
+    end
+
+    it "does not run on update" do
+      event = published_event
+      rsvp = EventRsvp.create!(event: event, user: user)
+      event.update!(status: "canceled")
+      expect(rsvp.save).to be true
+    end
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,191 @@
+require "rails_helper"
+
+RSpec.describe Event, type: :model do
+  let(:group) { Group.create!(name: "Test Group") }
+  let(:base_time) { Time.current.change(sec: 0) }
+
+  def build_event(overrides = {})
+    Event.new({
+      group: group,
+      title: "Test Event",
+      starts_at: base_time + 1.day,
+      ends_at: base_time + 1.day + 2.hours,
+      status: "draft",
+      visibility: "public"
+    }.merge(overrides))
+  end
+
+  def create_event(overrides = {})
+    build_event(overrides).tap(&:save!)
+  end
+
+  describe "validations" do
+    it "is valid with required fields" do
+      expect(build_event).to be_valid
+    end
+
+    it "requires a title" do
+      expect(build_event(title: "")).not_to be_valid
+    end
+
+    it "requires starts_at" do
+      event = build_event
+      event.starts_at = nil
+      expect(event).not_to be_valid
+    end
+
+    it "requires ends_at" do
+      event = build_event
+      event.ends_at = nil
+      expect(event).not_to be_valid
+    end
+
+    it "requires ends_at to be after starts_at" do
+      event = build_event(ends_at: base_time + 1.day - 1.hour)
+      expect(event).not_to be_valid
+      expect(event.errors[:ends_at]).to be_present
+    end
+
+    it "rejects ends_at equal to starts_at" do
+      t = base_time + 1.day
+      event = build_event(starts_at: t, ends_at: t)
+      expect(event).not_to be_valid
+    end
+
+    it "requires a valid status" do
+      expect(build_event(status: "unknown")).not_to be_valid
+    end
+
+    it "requires a valid visibility" do
+      expect(build_event(visibility: "secret")).not_to be_valid
+    end
+
+    it "accepts all valid statuses" do
+      Event::STATUSES.each do |s|
+        expect(build_event(status: s)).to be_valid
+      end
+    end
+
+    it "accepts all valid visibilities" do
+      Event::VISIBILITIES.each do |v|
+        expect(build_event(visibility: v)).to be_valid
+      end
+    end
+  end
+
+  describe "scopes" do
+    before do
+      create_event(status: "published", starts_at: base_time + 1.day, ends_at: base_time + 1.day + 1.hour)
+      create_event(status: "draft",     starts_at: base_time + 2.days, ends_at: base_time + 2.days + 1.hour)
+      create_event(status: "canceled",  starts_at: base_time + 3.days, ends_at: base_time + 3.days + 1.hour)
+    end
+
+    it ".published returns only published events" do
+      expect(Event.published.count).to eq(1)
+      expect(Event.published.first.status).to eq("published")
+    end
+
+    it ".draft returns only draft events" do
+      expect(Event.draft.count).to eq(1)
+    end
+
+    it ".canceled returns only canceled events" do
+      expect(Event.canceled.count).to eq(1)
+    end
+
+    it ".upcoming returns events starting in the future" do
+      past_event = create_event(starts_at: base_time - 2.days, ends_at: base_time - 1.day)
+      upcoming = Event.upcoming
+      expect(upcoming).not_to include(past_event)
+    end
+
+    it ".public_visibility returns only public events" do
+      create_event(visibility: "private")
+      public_events = Event.public_visibility
+      expect(public_events.map(&:visibility)).to all(eq("public"))
+    end
+  end
+
+  describe "#rsvp_open?" do
+    let(:event) { create_event(status: "published") }
+
+    it "returns true for a published event with no rsvp time restrictions" do
+      expect(event.rsvp_open?).to be true
+    end
+
+    it "returns false for a draft event" do
+      expect(create_event(status: "draft").rsvp_open?).to be false
+    end
+
+    it "returns false for a canceled event" do
+      expect(create_event(status: "canceled").rsvp_open?).to be false
+    end
+
+    it "returns false when rsvp_opens_at is in the future" do
+      event.update!(rsvp_opens_at: 1.hour.from_now)
+      expect(event.rsvp_open?).to be false
+    end
+
+    it "returns true when rsvp_opens_at is in the past" do
+      event.update!(rsvp_opens_at: 1.hour.ago)
+      expect(event.rsvp_open?).to be true
+    end
+
+    it "returns false when rsvp_closes_at is in the past" do
+      event.update!(rsvp_closes_at: 1.hour.ago)
+      expect(event.rsvp_open?).to be false
+    end
+
+    it "returns true when rsvp_closes_at is in the future" do
+      event.update!(rsvp_closes_at: 1.hour.from_now)
+      expect(event.rsvp_open?).to be true
+    end
+  end
+
+  describe "#rsvp_full?" do
+    let(:user) { User.create!(email: "u@example.com", password: "password") }
+    let(:event) { create_event(status: "published", rsvp_limit: 1) }
+
+    it "returns false when under the limit" do
+      expect(event.rsvp_full?).to be false
+    end
+
+    it "returns true when at the limit" do
+      event.update!(rsvp_opens_at: nil, rsvp_closes_at: nil)
+      EventRsvp.create!(event: event, user: user)
+      expect(event.rsvp_full?).to be true
+    end
+
+    it "returns false when rsvp_limit is nil" do
+      event.update!(rsvp_limit: nil)
+      expect(event.rsvp_full?).to be false
+    end
+  end
+
+  describe "#rsvped_by?" do
+    let(:user) { User.create!(email: "u@example.com", password: "password") }
+    let(:event) { create_event(status: "published") }
+
+    it "returns false when user has not RSVPed" do
+      expect(event.rsvped_by?(user)).to be false
+    end
+
+    it "returns true when user has RSVPed" do
+      EventRsvp.create!(event: event, user: user)
+      expect(event.rsvped_by?(user)).to be true
+    end
+
+    it "returns false for nil user" do
+      expect(event.rsvped_by?(nil)).to be false
+    end
+  end
+
+  describe "associations" do
+    it "destroys event_rsvps when event is destroyed" do
+      user = User.create!(email: "u@example.com", password: "password")
+      event = create_event(status: "published")
+      EventRsvp.create!(event: event, user: user)
+      expect { event.destroy }.to change { EventRsvp.count }.by(-1)
+    end
+  end
+end

--- a/spec/requests/event_rsvps_spec.rb
+++ b/spec/requests/event_rsvps_spec.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+RSpec.describe "EventRsvps", type: :request do
+  let(:user)       { User.create!(email: "user@example.com", password: "password") }
+  let(:other_user) { User.create!(email: "other@example.com", password: "password") }
+  let(:group)      { Group.create!(name: "Test Group") }
+  let(:base_time)  { Time.current.change(sec: 0) }
+
+  def published_event(overrides = {})
+    Event.create!({
+      group: group,
+      title: "Open Event",
+      starts_at: base_time + 1.day,
+      ends_at: base_time + 1.day + 2.hours,
+      status: "published",
+      visibility: "public"
+    }.merge(overrides))
+  end
+
+  describe "POST /events/:event_id/event_rsvps" do
+    let(:event) { published_event }
+
+    it "redirects unauthenticated users to sign in" do
+      post event_event_rsvps_path(event)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "creates an RSVP and redirects to the event" do
+      sign_in user
+      expect {
+        post event_event_rsvps_path(event)
+      }.to change(EventRsvp, :count).by(1)
+      expect(response).to redirect_to(event_path(event))
+      expect(flash[:notice]).to be_present
+    end
+
+    it "redirects with alert when RSVPs are not open (draft)" do
+      draft = Event.create!(group: group, title: "Draft", starts_at: base_time + 1.day,
+                            ends_at: base_time + 1.day + 1.hour, status: "draft")
+      sign_in user
+      post event_event_rsvps_path(draft)
+      expect(response).to redirect_to(event_path(draft))
+      expect(flash[:alert]).to be_present
+    end
+
+    it "redirects with alert when RSVPs haven't opened yet" do
+      event = published_event(rsvp_opens_at: 1.hour.from_now)
+      sign_in user
+      post event_event_rsvps_path(event)
+      expect(response).to redirect_to(event_path(event))
+      expect(flash[:alert]).to be_present
+    end
+
+    it "redirects with alert when RSVPs are closed" do
+      event = published_event(rsvp_closes_at: 1.hour.ago)
+      sign_in user
+      post event_event_rsvps_path(event)
+      expect(response).to redirect_to(event_path(event))
+      expect(flash[:alert]).to be_present
+    end
+
+    it "redirects with alert when event is full" do
+      event = published_event(rsvp_limit: 1)
+      EventRsvp.create!(event: event, user: other_user)
+      sign_in user
+      post event_event_rsvps_path(event)
+      expect(response).to redirect_to(event_path(event))
+      expect(flash[:alert]).to be_present
+    end
+
+    it "redirects with alert when user has already RSVPed" do
+      EventRsvp.create!(event: event, user: user)
+      sign_in user
+      post event_event_rsvps_path(event)
+      expect(response).to redirect_to(event_path(event))
+      expect(flash[:alert]).to be_present
+    end
+  end
+
+  describe "DELETE /event_rsvps/:id" do
+    let(:event) { published_event }
+    let!(:rsvp) { EventRsvp.create!(event: event, user: user) }
+
+    it "redirects unauthenticated users to sign in" do
+      delete event_rsvp_path(rsvp)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "allows user to cancel their own RSVP" do
+      sign_in user
+      expect {
+        delete event_rsvp_path(rsvp)
+      }.to change(EventRsvp, :count).by(-1)
+      expect(response).to redirect_to(event_path(event))
+      expect(flash[:notice]).to be_present
+    end
+
+    it "prevents user from canceling another's RSVP" do
+      sign_in other_user
+      delete event_rsvp_path(rsvp)
+      expect(EventRsvp.exists?(rsvp.id)).to be true
+      expect(response).to redirect_to(event_path(event))
+      expect(flash[:alert]).to be_present
+    end
+  end
+end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1,0 +1,255 @@
+require "rails_helper"
+
+RSpec.describe "Events", type: :request do
+  let(:organizer) { User.create!(email: "organizer@example.com", password: "password") }
+  let(:member)    { User.create!(email: "member@example.com", password: "password") }
+  let(:outsider)  { User.create!(email: "outsider@example.com", password: "password") }
+  let(:group) { Group.create!(name: "Test Group") }
+  let(:base_time) { Time.current.change(sec: 0) }
+
+  def make_organizer(u, g = group)
+    g.group_memberships.create!(user: u, role: "organizer")
+  end
+
+  def make_member(u, g = group)
+    g.group_memberships.create!(user: u, role: "member")
+  end
+
+  def create_event(overrides = {})
+    Event.create!({
+      group: group,
+      title: "Test Event",
+      starts_at: base_time + 1.day,
+      ends_at: base_time + 1.day + 2.hours,
+      status: "published",
+      visibility: "public"
+    }.merge(overrides))
+  end
+
+  let(:event_params) do
+    {
+      title: "New Event",
+      starts_at: (base_time + 2.days).strftime("%Y-%m-%dT%H:%M"),
+      ends_at: (base_time + 2.days + 2.hours).strftime("%Y-%m-%dT%H:%M"),
+      status: "draft",
+      visibility: "public"
+    }
+  end
+
+  describe "GET /groups/:group_id/events" do
+    before { make_organizer(organizer); make_member(member) }
+
+    it "redirects unauthenticated users" do
+      get group_events_path(group)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "redirects non-member outsiders" do
+      sign_in outsider
+      get group_events_path(group)
+      expect(response).to redirect_to(group_path(group))
+    end
+
+    it "returns 200 for group members" do
+      sign_in member
+      get group_events_path(group)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns 200 for organizer" do
+      sign_in organizer
+      get group_events_path(group)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "shows all statuses to organizer" do
+      create_event(status: "draft", title: "Draft")
+      create_event(status: "published", title: "Published")
+      sign_in organizer
+      get group_events_path(group)
+      expect(response.body).to include("Draft", "Published")
+    end
+
+    it "shows only published events to members" do
+      create_event(status: "draft", title: "Hidden Draft")
+      create_event(status: "published", title: "Visible Published")
+      sign_in member
+      get group_events_path(group)
+      expect(response.body).to include("Visible Published")
+      expect(response.body).not_to include("Hidden Draft")
+    end
+  end
+
+  describe "GET /events/:id (public + published)" do
+    let(:event) { create_event(status: "published", visibility: "public") }
+
+    it "returns 200 for unauthenticated visitors" do
+      get event_path(event)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns 200 for a member" do
+      make_member(member)
+      sign_in member
+      get event_path(event)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /events/:id (private + published)" do
+    let(:event) { create_event(status: "published", visibility: "private") }
+
+    it "redirects unauthenticated visitors" do
+      get event_path(event)
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "redirects outsiders (not a group member)" do
+      sign_in outsider
+      get event_path(event)
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "returns 200 for group members" do
+      make_member(member)
+      sign_in member
+      get event_path(event)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /events/:id (draft)" do
+    let(:event) { create_event(status: "draft") }
+
+    it "redirects unauthenticated visitors" do
+      get event_path(event)
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "redirects non-organizer members" do
+      make_member(member)
+      sign_in member
+      get event_path(event)
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "returns 200 for organizers" do
+      make_organizer(organizer)
+      sign_in organizer
+      get event_path(event)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /groups/:group_id/events/new" do
+    it "redirects unauthenticated users" do
+      get new_group_event_path(group)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "redirects non-organizers" do
+      make_member(member)
+      sign_in member
+      get new_group_event_path(group)
+      expect(response).to redirect_to(group_path(group))
+    end
+
+    it "returns 200 for organizers" do
+      make_organizer(organizer)
+      sign_in organizer
+      get new_group_event_path(group)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /groups/:group_id/events" do
+    before { make_organizer(organizer) }
+
+    it "redirects unauthenticated users" do
+      post group_events_path(group), params: { event: event_params }
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "creates an event and redirects" do
+      sign_in organizer
+      expect {
+        post group_events_path(group), params: { event: event_params }
+      }.to change(Event, :count).by(1)
+      expect(response).to redirect_to(event_path(Event.last))
+    end
+
+    it "re-renders new with errors on invalid params" do
+      sign_in organizer
+      post group_events_path(group), params: { event: event_params.merge(title: "") }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "GET /events/:id/edit" do
+    let(:event) { create_event(status: "draft") }
+
+    it "redirects unauthenticated users" do
+      get edit_event_path(event)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "redirects non-organizers" do
+      make_member(member)
+      sign_in member
+      get edit_event_path(event)
+      expect(response).to redirect_to(event_path(event))
+    end
+
+    it "returns 200 for organizers" do
+      make_organizer(organizer)
+      sign_in organizer
+      get edit_event_path(event)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "PATCH /events/:id" do
+    let(:event) { create_event(status: "draft") }
+
+    it "redirects non-organizers" do
+      make_member(member)
+      sign_in member
+      patch event_path(event), params: { event: { title: "Changed" } }
+      expect(response).to redirect_to(event_path(event))
+    end
+
+    it "updates the event for organizers" do
+      make_organizer(organizer)
+      sign_in organizer
+      patch event_path(event), params: { event: { title: "Updated Title", status: "published" } }
+      expect(event.reload.title).to eq("Updated Title")
+      expect(event.reload.status).to eq("published")
+    end
+
+    it "re-renders edit with errors on invalid params" do
+      make_organizer(organizer)
+      sign_in organizer
+      patch event_path(event), params: { event: { title: "" } }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "DELETE /events/:id" do
+    let(:event) { create_event(status: "draft") }
+
+    it "redirects non-organizers" do
+      make_member(member)
+      sign_in member
+      delete event_path(event)
+      expect(response).to redirect_to(event_path(event))
+    end
+
+    it "destroys the event for organizers" do
+      make_organizer(organizer)
+      sign_in organizer
+      delete event_path(event)
+      expect(Event.exists?(event.id)).to be false
+      expect(response).to redirect_to(group_events_path(group))
+    end
+  end
+end


### PR DESCRIPTION
This should handle issue 17: https://github.com/techsavannah/calmendar/issues/17

## Summary

- **Events** belong to a group and support draft/published/canceled status, public/private visibility, markdown descriptions, location, start/end times, and optional RSVP limit + opens/closes datetimes
- **RSVPs** let authenticated group members register for published events; respects capacity limits and the RSVP window
- **Authorization**: organizers manage full event lifecycle; members see all published events (including private); public events visible unauthenticated
- **Homepage**: logged-in users see upcoming events from their groups + a "Discover Events" section for public events from other groups; unauthenticated visitors see upcoming public events on the landing page

## Test plan

- [x] Run `bundle exec rspec` — 143 examples, 0 failures
- [x] Run `bin/rubocop` — no offenses
- [x] Run `bin/brakeman --no-pager` — no warnings
- [x] Create a group event as an organizer, save as draft
- [x] Publish the event and verify it appears on the group page and homepage
- [x] RSVP as a member; verify count updates
- [x] Set an RSVP limit and verify the button disables when full
- [x] Set `rsvp_closes_at` in the past and verify RSVP is blocked
- [x] Verify a private published event is not visible to non-members
- [x] Verify draft events are not visible to non-organizers
- [x] Verify public events from other groups appear in "Discover Events"
- [x] Verify public events appear on the landing page when logged out

🤖 Generated with [Claude Code](https://claude.com/claude-code)